### PR TITLE
Update error logging

### DIFF
--- a/src/EA.Iws.Api/EA.Iws.Api.csproj
+++ b/src/EA.Iws.Api/EA.Iws.Api.csproj
@@ -243,8 +243,8 @@
     <Compile Include="Controllers\RegistrationController.cs" />
     <Compile Include="Identity\UserContext.cs" />
     <Compile Include="IdSrv\Clients.cs" />
-    <Compile Include="IdSrv\DebugLogger.cs" />
-    <Compile Include="IdSrv\ElmahLogger.cs" />
+    <Compile Include="Infrastructure\DebugLogSink.cs" />
+    <Compile Include="Infrastructure\ElmahLogSink.cs" />
     <Compile Include="IdSrv\Factory.cs" />
     <Compile Include="IdSrv\Scopes.cs" />
     <Compile Include="IdSrv\UserService.cs" />

--- a/src/EA.Iws.Api/EA.Iws.Api.csproj
+++ b/src/EA.Iws.Api/EA.Iws.Api.csproj
@@ -169,6 +169,10 @@
       <HintPath>..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Serilog.Sinks.EventLog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.EventLog.1.5.11\lib\net45\Serilog.Sinks.EventLog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.20622.1351, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.4.0.2.206221351\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
@@ -250,6 +254,7 @@
     <Compile Include="IdSrv\UserService.cs" />
     <Compile Include="IdSrv\UserServiceExtensions.cs" />
     <Compile Include="Infrastructure\ApiControllerExtensions.cs" />
+    <Compile Include="Infrastructure\LoggerConfigurationExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\AppConfiguration.cs" />
     <Compile Include="Services\ConfigurationService.cs" />

--- a/src/EA.Iws.Api/Infrastructure/DebugLogSink.cs
+++ b/src/EA.Iws.Api/Infrastructure/DebugLogSink.cs
@@ -1,4 +1,4 @@
-﻿namespace EA.Iws.Api.IdSrv
+﻿namespace EA.Iws.Api.Infrastructure
 {
     using System.Diagnostics;
     using System.IO;
@@ -6,11 +6,11 @@
     using Serilog.Events;
     using Serilog.Formatting.Display;
 
-    internal class DebugLogger : ILogEventSink
+    internal class DebugLogSink : ILogEventSink
     {
         private readonly MessageTemplateTextFormatter formatter;
 
-        public DebugLogger(MessageTemplateTextFormatter formatter)
+        public DebugLogSink(MessageTemplateTextFormatter formatter)
         {
             this.formatter = formatter;
         }

--- a/src/EA.Iws.Api/Infrastructure/ElmahLogSink.cs
+++ b/src/EA.Iws.Api/Infrastructure/ElmahLogSink.cs
@@ -1,10 +1,10 @@
-﻿namespace EA.Iws.Api.IdSrv
+﻿namespace EA.Iws.Api.Infrastructure
 {
     using Elmah;
     using Serilog.Core;
     using Serilog.Events;
 
-    internal class ElmahLogger : ILogEventSink
+    internal class ElmahLogSink : ILogEventSink
     {
         public void Emit(LogEvent logEvent)
         {

--- a/src/EA.Iws.Api/Infrastructure/LoggerConfigurationExtensions.cs
+++ b/src/EA.Iws.Api/Infrastructure/LoggerConfigurationExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace EA.Iws.Api.Infrastructure
+{
+    using System;
+    using Prsd.Core;
+    using Serilog;
+    using Serilog.Configuration;
+    using Serilog.Formatting.Display;
+
+    internal static class LoggerConfigurationExtensions
+    {
+        private const string DefaultOutputTemplate = "{Timestamp} [{Level}] {Message}{NewLine}{Exception}";
+
+        public static LoggerConfiguration Debug(this LoggerSinkConfiguration loggerConfiguration,
+            string outputTemplate = DefaultOutputTemplate,
+            IFormatProvider formatProvider = null)
+        {
+            Guard.ArgumentNotNull(() => loggerConfiguration, loggerConfiguration);
+
+            var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+            return loggerConfiguration.Sink(new DebugLogSink(formatter));
+        }
+
+        public static LoggerConfiguration Elmah(this LoggerSinkConfiguration loggerConfiguration)
+        {
+            Guard.ArgumentNotNull(() => loggerConfiguration, loggerConfiguration);
+
+            return loggerConfiguration.Sink(new ElmahLogSink());
+        }
+    }
+}

--- a/src/EA.Iws.Api/Startup.cs
+++ b/src/EA.Iws.Api/Startup.cs
@@ -14,6 +14,7 @@ namespace EA.Iws.Api
     using IdentityServer3.AccessTokenValidation;
     using IdentityServer3.Core.Configuration;
     using IdSrv;
+    using Infrastructure;
     using Microsoft.Owin.Security.DataProtection;
     using Newtonsoft.Json.Serialization;
     using Owin;
@@ -29,7 +30,7 @@ namespace EA.Iws.Api
             var configurationService = new ConfigurationService();
 #if DEBUG
             Log.Logger = new LoggerConfiguration()
-                .WriteTo.Sink(new DebugLogger(new MessageTemplateTextFormatter("{Message}{NewLine}{Exception}", null)))
+                .WriteTo.Sink(new DebugLogSink(new MessageTemplateTextFormatter("{Message}{NewLine}{Exception}", null)))
                 .CreateLogger();
 
             config.Services.Add(typeof(IExceptionLogger), new DebugExceptionLogger());

--- a/src/EA.Iws.Api/packages.config
+++ b/src/EA.Iws.Api/packages.config
@@ -41,6 +41,7 @@
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Serilog" version="1.5.14" targetFramework="net452" />
+  <package id="Serilog.Sinks.EventLog" version="1.5.11" targetFramework="net452" />
   <package id="StyleCop.Error.MSBuild" version="1.0.0" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net452" developmentDependency="true" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" targetFramework="net452" />

--- a/src/EA.Iws.Web/Web.config
+++ b/src/EA.Iws.Web/Web.config
@@ -134,6 +134,26 @@
   </appSettings>
   <elmah>
     <errorLog type="Elmah.XmlFileErrorLog, Elmah" logPath="~/App_Data" />
+    <errorFilter>
+      <test>
+        <!--
+          Don't log 404 errors for unauthenticated users.
+          
+          Most of the time these are the result of the application being
+          probed for vulnerabilites. If the application has responded with
+          a 404 then no further action is required and we don't need to
+          log this as an application error.
+          
+          The request will still be logged by IIS along with the
+          source IP address which is sufficient to take action against
+          denial of service atttacks.
+        -->
+        <and>
+          <equal binding="HttpStatusCode" value="404" type="Int32" />
+          <equal binding="Context.Request.ServerVariables['AUTH_USER']" value="" type="String" />
+        </and>
+      </test>
+    </errorFilter>
   </elmah>
   <system.net>
     <mailSettings>


### PR DESCRIPTION
- Refactor the Serilog Sinks into the Infrastructure namespace and create `LoggerConfigurationExtensions` to create the Sinks
- Update `MediatorController` to use Serilog to log errors instead of using Elmah directly
- Update Elmah config in web to filter out 404 errors for unauthenticated users
- Add Serilog Sink to log to Windows Event Log.