### PR TITLE
Elmah logging security filter

### DIFF
--- a/src/EA.Iws.Web/EA.Iws.Web.csproj
+++ b/src/EA.Iws.Web/EA.Iws.Web.csproj
@@ -1873,6 +1873,7 @@
     <Compile Include="Infrastructure\VirusScanning\VirusFoundException.cs" />
     <Compile Include="Infrastructure\VirusScanning\VirusFoundFilter.cs" />
     <Compile Include="Infrastructure\VirusScanning\WriteFileVirusScanner.cs" />
+    <Compile Include="Logging\ElmahFilter.cs" />
     <Compile Include="Mappings\ImportNotificationAssessment\FinancialGuarantee\FinancialGuaranteeDecisionViewModelMap.cs" />
     <Compile Include="ViewModels\Shared\IComplete.cs" />
     <Compile Include="Areas\AdminExportMovement\ViewModels\InternalCapture\ReceiptViewModel.cs" />

--- a/src/EA.Iws.Web/Global.asax.cs
+++ b/src/EA.Iws.Web/Global.asax.cs
@@ -5,6 +5,8 @@
     using System.Web.Mvc;
     using System.Web.Optimization;
     using System.Web.Routing;
+    using Elmah;
+    using Logging;
 
     public class Global : HttpApplication
     {
@@ -19,6 +21,16 @@
         protected void Application_PreSendRequestHeaders(object sender, EventArgs e)
         {
             HttpContext.Current.Response.Headers.Remove("Server");
+        }
+
+        protected void ErrorLog_Filtering(object sender, ExceptionFilterEventArgs args)
+        {
+            ElmahFilter.FilterSensitiveData(args);
+        }
+
+        protected void ErrorMail_Filtering(object sender, ExceptionFilterEventArgs args)
+        {
+            ElmahFilter.FilterSensitiveData(args);
         }
     }
 }

--- a/src/EA.Iws.Web/Logging/ElmahFilter.cs
+++ b/src/EA.Iws.Web/Logging/ElmahFilter.cs
@@ -1,0 +1,49 @@
+﻿namespace EA.Iws.Web.Logging
+{
+    using Elmah;
+    using System;
+    using System.Linq;
+    using System.Web;
+
+    public static class ElmahFilter
+    {
+        private static string[] sensitiveFieldNames = { "Password", "ConfirmPassword" };
+
+        /// <summary>
+        /// This method checks the HttpContext associated with the Exception for any sensitive
+        /// data submitted in the form that should not be logged in plain text.
+        /// If fields are found that match the names in the SensitiveFieldNames list, their values
+        /// are replaced with **** before the error is logged.
+        /// </summary>
+        /// <param name="args"></param>
+        internal static void FilterSensitiveData(ExceptionFilterEventArgs args)
+        {
+            if (args.Context != null)
+            {
+                HttpContext context = (HttpContext)args.Context;
+                if (context.Request != null &&
+                    context.Request.Form != null &&
+                    context.Request.Form.AllKeys.Intersect(sensitiveFieldNames, StringComparer.InvariantCultureIgnoreCase).Any())
+                {
+                    ReplaceSensitiveFormFields(args, context);
+                }
+            }
+        }
+
+        private static void ReplaceSensitiveFormFields(ExceptionFilterEventArgs args, HttpContext context)
+        {
+            var replacementError = new Error(args.Exception, (HttpContext)args.Context);
+
+            foreach (var formField in context.Request.Form.AllKeys)
+            {
+                if (sensitiveFieldNames.Contains(formField, StringComparer.InvariantCultureIgnoreCase))
+                {
+                    replacementError.Form.Set(formField, "****");
+                }
+            }
+
+            ErrorLog.GetDefault(HttpContext.Current).Log(replacementError);
+            args.Dismiss();
+        }
+    }
+}


### PR DESCRIPTION
Having searched the app for password entry fields, "Password" and "ConfirmPassword" appear to be the only names of form fields that we do not want to be logged.