### PR TITLE
Add remittance postal address for all UK CAs

### DIFF
--- a/src/EA.Iws.Database/EA.Iws.Database.csproj
+++ b/src/EA.Iws.Database/EA.Iws.Database.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Content Include="scripts\Update\Sprint28\20160316-1233-fix-bank-address-typo.sql" />
     <Content Include="Readme.txt" />
     <Content Include="scripts\AliaSQL.exe" />
     <Content Include="scripts\Create\placeholder.txt" />

--- a/src/EA.Iws.Database/EA.Iws.Database.csproj
+++ b/src/EA.Iws.Database/EA.Iws.Database.csproj
@@ -260,6 +260,7 @@
     <Content Include="scripts\Update\Sprint27\20160218-104500-create-export-consultation-table.sql" />
     <Content Include="scripts\Update\Sprint27\20160225-090100-update-competent-authorities.sql" />
     <Content Include="scripts\Update\Sprint28\20160315-111500-remove-unused-uk-ca-columns.sql" />
+    <Content Include="scripts\Update\Sprint28\20160316-1138-insert-uk-ca-remittance-address.sql" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="scripts\TestData\20150522-171900-link-test-user-to-org.sql" />

--- a/src/EA.Iws.Database/scripts/Update/Sprint28/20160316-1138-insert-uk-ca-remittance-address.sql
+++ b/src/EA.Iws.Database/scripts/Update/Sprint28/20160316-1138-insert-uk-ca-remittance-address.sql
@@ -1,0 +1,17 @@
+﻿-- Set SEPA address
+UPDATE [Lookup].[UnitedKingdomCompetentAuthority]
+SET [RemittancePostalAddress]='Scottish Environment Protection Agency, Producer Compliance and Waste Shipment Unit, Strathallan House, The Castle Business Park, Stirling, FK9 4TZ'
+WHERE [Id] = 2
+
+-- Set NIEA address
+UPDATE [Lookup].[UnitedKingdomCompetentAuthority]
+SET [RemittancePostalAddress]='Northern Ireland Environment Agency, TFS Section, 1st Floor Klondyke Building, Cromac Avenue, Gasworks Business Park, Malone Lower, Belfast, BT7 2JA'
+WHERE [Id] = 3
+
+-- Set NRW address
+UPDATE [Lookup].[UnitedKingdomCompetentAuthority]
+SET [RemittancePostalAddress]='Natural Resources Wales, Waste Shipment Unit, Plas-yr-Afon/Rivers House, St. Mellons Business Park, Cardiff, CF3 0EY'
+WHERE [Id] = 4
+
+-- Set [RemittancePostalAddress] as non-nullable
+ALTER TABLE [Lookup].[UnitedKingdomCompetentAuthority] ALTER COLUMN [RemittancePostalAddress] NVARCHAR(4000) NOT NULL

--- a/src/EA.Iws.Database/scripts/Update/Sprint28/20160316-1233-fix-bank-address-typo.sql
+++ b/src/EA.Iws.Database/scripts/Update/Sprint28/20160316-1233-fix-bank-address-typo.sql
@@ -1,0 +1,4 @@
+﻿-- Set SEPA address
+UPDATE [Lookup].[UnitedKingdomCompetentAuthority]
+SET [BacsBankAddress]='Royal Bank of Scotland plc, London Corporate Service Centre, CPB Services 2nd Floor, 280 Bishopsgate, London, EC2M 4RB'
+WHERE [Id] = 1

--- a/src/EA.Iws.Database/scripts/Update/Sprint28/20160316-1233-fix-bank-address-typo.sql
+++ b/src/EA.Iws.Database/scripts/Update/Sprint28/20160316-1233-fix-bank-address-typo.sql
@@ -1,4 +1,3 @@
-﻿-- Set SEPA address
-UPDATE [Lookup].[UnitedKingdomCompetentAuthority]
+﻿UPDATE [Lookup].[UnitedKingdomCompetentAuthority]
 SET [BacsBankAddress]='Royal Bank of Scotland plc, London Corporate Service Centre, CPB Services 2nd Floor, 280 Bishopsgate, London, EC2M 4RB'
 WHERE [Id] = 1

--- a/src/EA.Iws.Web/Areas/NotificationApplication/Views/WhatToDoNext/_RemittancePost.cshtml
+++ b/src/EA.Iws.Web/Areas/NotificationApplication/Views/WhatToDoNext/_RemittancePost.cshtml
@@ -3,4 +3,4 @@
 
 <p>@Resources.RemittancePost
 <br/>
-@Html.Raw(Model.UnitedKingdomCompetentAuthorityData.BacsDetails.RemittanceAddress ?? Model.UnitedKingdomCompetentAuthorityData.Address.ToString().Replace(", ,", ","))</p>
+@Html.Raw(Model.UnitedKingdomCompetentAuthorityData.BacsDetails.RemittanceAddress)</p>


### PR DESCRIPTION
It is safe to leave the CA addresses out of the database and populate the remittance addresses instead.