### PR TITLE
Access token lifetime

### DIFF
--- a/src/EA.Iws.Api.Client/EA.Iws.Api.Client.csproj
+++ b/src/EA.Iws.Api.Client/EA.Iws.Api.Client.csproj
@@ -32,12 +32,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core.Web, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16048-develop1\lib\net452\EA.Prsd.Core.Web.dll</HintPath>
+    <Reference Include="EA.Prsd.Core.Web, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16077-develop1\lib\net452\EA.Prsd.Core.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="IdentityModel, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/EA.Iws.Api.Client/packages.config
+++ b/src/EA.Iws.Api.Client/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
-  <package id="EA.Prsd.Core.Web" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core.Web" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="IdentityModel" version="1.6.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />

--- a/src/EA.Iws.Api.Tests.Unit/EA.Iws.Api.Tests.Unit.csproj
+++ b/src/EA.Iws.Api.Tests.Unit/EA.Iws.Api.Tests.Unit.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">

--- a/src/EA.Iws.Api.Tests.Unit/packages.config
+++ b/src/EA.Iws.Api.Tests.Unit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="FakeItEasy" version="2.0.0-beta010" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />

--- a/src/EA.Iws.Api/EA.Iws.Api.csproj
+++ b/src/EA.Iws.Api/EA.Iws.Api.csproj
@@ -65,16 +65,16 @@
       <Private>True</Private>
       <HintPath>..\packages\DocumentFormat.OpenXml.2.5\lib\DocumentFormat.OpenXml.dll</HintPath>
     </Reference>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core.Autofac, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Autofac.1.0.16048-develop1\lib\net452\EA.Prsd.Core.Autofac.dll</HintPath>
+    <Reference Include="EA.Prsd.Core.Autofac, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Autofac.1.0.16077-develop1\lib\net452\EA.Prsd.Core.Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core.Web, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16048-develop1\lib\net452\EA.Prsd.Core.Web.dll</HintPath>
+    <Reference Include="EA.Prsd.Core.Web, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16077-develop1\lib\net452\EA.Prsd.Core.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Elmah">

--- a/src/EA.Iws.Api/IdSrv/Clients.cs
+++ b/src/EA.Iws.Api/IdSrv/Clients.cs
@@ -22,7 +22,8 @@
                     {
                         new Secret(config.ApiSecret.Sha256())
                     },
-                    AllowAccessToAllScopes = true
+                    AllowAccessToAllScopes = true,
+                    AccessTokenLifetime = 43200 // 12 hours
                 }
             };
         }

--- a/src/EA.Iws.Api/packages.config
+++ b/src/EA.Iws.Api/packages.config
@@ -6,9 +6,9 @@
   <package id="Autofac.WebApi2.Owin" version="3.3.0" targetFramework="net452" />
   <package id="AutoMapper" version="4.2.0" targetFramework="net452" />
   <package id="DocumentFormat.OpenXml" version="2.5" targetFramework="net452" />
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
-  <package id="EA.Prsd.Core.Autofac" version="1.0.16048-develop1" targetFramework="net452" />
-  <package id="EA.Prsd.Core.Web" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core.Autofac" version="1.0.16077-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core.Web" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="elmah" version="1.2.2" targetFramework="net452" />
   <package id="Elmah.Contrib.WebApi" version="1.0.10.25" targetFramework="net452" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net452" />

--- a/src/EA.Iws.Core/EA.Iws.Core.csproj
+++ b/src/EA.Iws.Core/EA.Iws.Core.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/EA.Iws.Core/packages.config
+++ b/src/EA.Iws.Core/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="StyleCop.Error.MSBuild" version="1.0.0" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/EA.Iws.DataAccess.Tests.Integration/EA.Iws.DataAccess.Tests.Integration.csproj
+++ b/src/EA.Iws.DataAccess.Tests.Integration/EA.Iws.DataAccess.Tests.Integration.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework">

--- a/src/EA.Iws.DataAccess.Tests.Integration/packages.config
+++ b/src/EA.Iws.DataAccess.Tests.Integration/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="FakeItEasy" version="2.0.0-beta010" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />

--- a/src/EA.Iws.DataAccess/EA.Iws.DataAccess.csproj
+++ b/src/EA.Iws.DataAccess/EA.Iws.DataAccess.csproj
@@ -38,12 +38,12 @@
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.DataAccess.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.DataAccess.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core.DataAccess, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.DataAccess.1.0.16048-develop1\lib\net452\EA.Prsd.Core.DataAccess.dll</HintPath>
+    <Reference Include="EA.Prsd.Core.DataAccess, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.DataAccess.1.0.16077-develop1\lib\net452\EA.Prsd.Core.DataAccess.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/src/EA.Iws.DataAccess/packages.config
+++ b/src/EA.Iws.DataAccess/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net452" />
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
-  <package id="EA.Prsd.Core.DataAccess" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core.DataAccess" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.1" targetFramework="net452" />

--- a/src/EA.Iws.Database/EA.Iws.Database.csproj
+++ b/src/EA.Iws.Database/EA.Iws.Database.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/EA.Iws.Database/packages.config
+++ b/src/EA.Iws.Database/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AliaSQL.Kickstarter" version="1.4.0.1208" targetFramework="net452" />
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="StyleCop.Error.MSBuild" version="1.0.0" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/EA.Iws.DocumentGeneration.Tests.Unit/EA.Iws.DocumentGeneration.Tests.Unit.csproj
+++ b/src/EA.Iws.DocumentGeneration.Tests.Unit/EA.Iws.DocumentGeneration.Tests.Unit.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">

--- a/src/EA.Iws.DocumentGeneration.Tests.Unit/packages.config
+++ b/src/EA.Iws.DocumentGeneration.Tests.Unit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="FakeItEasy" version="2.0.0-beta010" targetFramework="net452" />
   <package id="StyleCop.Error.MSBuild" version="1.0.0" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net452" developmentDependency="true" />

--- a/src/EA.Iws.DocumentGeneration/EA.Iws.DocumentGeneration.csproj
+++ b/src/EA.Iws.DocumentGeneration/EA.Iws.DocumentGeneration.csproj
@@ -41,8 +41,8 @@
       <Private>True</Private>
       <HintPath>..\packages\DocumentFormat.OpenXml.2.5\lib\DocumentFormat.OpenXml.dll</HintPath>
     </Reference>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/EA.Iws.DocumentGeneration/packages.config
+++ b/src/EA.Iws.DocumentGeneration/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net452" />
   <package id="DocumentFormat.OpenXml" version="2.5" targetFramework="net452" />
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="StyleCop.Error.MSBuild" version="1.0.0" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/EA.Iws.Domain.Tests.Unit/EA.Iws.Domain.Tests.Unit.csproj
+++ b/src/EA.Iws.Domain.Tests.Unit/EA.Iws.Domain.Tests.Unit.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">

--- a/src/EA.Iws.Domain.Tests.Unit/packages.config
+++ b/src/EA.Iws.Domain.Tests.Unit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="FakeItEasy" version="2.0.0-beta010" targetFramework="net452" />
   <package id="StyleCop.Error.MSBuild" version="1.0.0" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net452" developmentDependency="true" />

--- a/src/EA.Iws.Domain/EA.Iws.Domain.csproj
+++ b/src/EA.Iws.Domain/EA.Iws.Domain.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Stateless, Version=2.5.36.0, Culture=neutral, PublicKeyToken=93038f0927583c9a, processorArchitecture=MSIL">

--- a/src/EA.Iws.Domain/packages.config
+++ b/src/EA.Iws.Domain/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="Stateless" version="2.5.36.0" targetFramework="net452" />
   <package id="StyleCop.Error.MSBuild" version="1.0.0" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net452" developmentDependency="true" />

--- a/src/EA.Iws.EmailMessaging/EA.Iws.EmailMessaging.csproj
+++ b/src/EA.Iws.EmailMessaging/EA.Iws.EmailMessaging.csproj
@@ -35,12 +35,12 @@
     <Reference Include="Autofac">
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Email, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Email.1.0.16048-develop1\lib\net451\EA.Prsd.Email.dll</HintPath>
+    <Reference Include="EA.Prsd.Email, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Email.1.0.16077-develop1\lib\net451\EA.Prsd.Email.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RazorEngine, Version=3.7.7.0, Culture=neutral, PublicKeyToken=9ee697374c7e744a, processorArchitecture=MSIL">

--- a/src/EA.Iws.EmailMessaging/packages.config
+++ b/src/EA.Iws.EmailMessaging/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net452" />
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
-  <package id="EA.Prsd.Email" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Email" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
   <package id="RazorEngine" version="3.7.7" targetFramework="net452" />
   <package id="StyleCop.Error.MSBuild" version="1.0.0" targetFramework="net452" />

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/packages.config
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="FakeItEasy" version="2.0.0-beta010" targetFramework="net452" />
   <package id="FluentValidation" version="6.1.0.0" targetFramework="net452" />

--- a/src/EA.Iws.RequestHandlers/EA.Iws.RequestHandlers.csproj
+++ b/src/EA.Iws.RequestHandlers/EA.Iws.RequestHandlers.csproj
@@ -40,12 +40,12 @@
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Autofac.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Autofac.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core.Autofac, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Autofac.1.0.16048-develop1\lib\net452\EA.Prsd.Core.Autofac.dll</HintPath>
+    <Reference Include="EA.Prsd.Core.Autofac, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Autofac.1.0.16077-develop1\lib\net452\EA.Prsd.Core.Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/src/EA.Iws.RequestHandlers/packages.config
+++ b/src/EA.Iws.RequestHandlers/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net452" />
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
-  <package id="EA.Prsd.Core.Autofac" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core.Autofac" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="FluentValidation" version="6.1.0.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net452" />

--- a/src/EA.Iws.Requests/EA.Iws.Requests.csproj
+++ b/src/EA.Iws.Requests/EA.Iws.Requests.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/EA.Iws.Requests/packages.config
+++ b/src/EA.Iws.Requests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="StyleCop.Error.MSBuild" version="1.0.0" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/EA.Iws.TestHelpers/EA.Iws.TestHelpers.csproj
+++ b/src/EA.Iws.TestHelpers/EA.Iws.TestHelpers.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/EA.Iws.TestHelpers/packages.config
+++ b/src/EA.Iws.TestHelpers/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="StyleCop.Error.MSBuild" version="1.0.0" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net452" developmentDependency="true" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net452" />

--- a/src/EA.Iws.Web.Tests.Unit/EA.Iws.Web.Tests.Unit.csproj
+++ b/src/EA.Iws.Web.Tests.Unit/EA.Iws.Web.Tests.Unit.csproj
@@ -55,12 +55,12 @@
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core.Web, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16048-develop1\lib\net452\EA.Prsd.Core.Web.dll</HintPath>
+    <Reference Include="EA.Prsd.Core.Web, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Web.1.0.16077-develop1\lib\net452\EA.Prsd.Core.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">

--- a/src/EA.Iws.Web.Tests.Unit/packages.config
+++ b/src/EA.Iws.Web.Tests.Unit/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net452" />
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
-  <package id="EA.Prsd.Core.Web" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core.Web" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="FakeItEasy" version="2.0.0-beta010" targetFramework="net452" />
   <package id="IdentityModel" version="1.6.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net452" />

--- a/src/EA.Iws.Web/App_Start/Startup.Auth.cs
+++ b/src/EA.Iws.Web/App_Start/Startup.Auth.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Net;
+    using System.Threading.Tasks;
     using Infrastructure;
     using Microsoft.Owin;
     using Microsoft.Owin.Security.Cookies;
@@ -22,10 +23,16 @@
                 ExpireTimeSpan = TimeSpan.FromHours(2),
                 Provider = new CookieAuthenticationProvider
                 {
-                    OnValidateIdentity = context => IdentityValidationHelper.OnValidateIdentity(context),
+                    OnValidateIdentity = context => OnValidateIdentity(context),
                     OnApplyRedirect = context => OnApplyRedirect(context)
                 }
             });
+        }
+
+        private static async Task OnValidateIdentity(CookieValidateIdentityContext context)
+        {
+            await IdentityValidationHelper.UpdateAccessToken(context);
+            await IdentityValidationHelper.TransformClaims(context);
         }
 
         private static void OnApplyRedirect(CookieApplyRedirectContext context)

--- a/src/EA.Iws.Web/App_Start/Startup.Auth.cs
+++ b/src/EA.Iws.Web/App_Start/Startup.Auth.cs
@@ -1,14 +1,17 @@
 ﻿namespace EA.Iws.Web
 {
     using System;
+    using System.Globalization;
     using System.Net;
     using System.Threading.Tasks;
-    using Infrastructure;
     using Microsoft.Owin;
     using Microsoft.Owin.Security.Cookies;
     using Owin;
+    using Prsd.Core;
+    using Prsd.Core.Web;
     using Prsd.Core.Web.Mvc.Owin;
     using Services;
+    using Constants = Infrastructure.Constants;
 
     public partial class Startup
     {
@@ -31,7 +34,8 @@
 
         private static async Task OnValidateIdentity(CookieValidateIdentityContext context)
         {
-            await IdentityValidationHelper.UpdateAccessToken(context);
+            CheckAccessToken(context);
+
             await IdentityValidationHelper.TransformClaims(context);
         }
 
@@ -45,6 +49,35 @@
             {
                 context.Response.Redirect(context.RedirectUri);
             }
+        }
+
+        private static void CheckAccessToken(CookieValidateIdentityContext context)
+        {
+            var expiresAt = context.Identity.FindFirst(ClaimTypes.ExpiresAt);
+            if (expiresAt != null)
+            {
+                DateTime expiryDate;
+
+                if (!DateTime.TryParseExact(expiresAt.Value, "u", CultureInfo.InvariantCulture,
+                    DateTimeStyles.AdjustToUniversal, out expiryDate))
+                {
+                    // If the expiry date can't be parsed then sign the user out.
+                    RejectIdentity(context);
+                    return;
+                }
+
+                if (expiryDate < SystemTime.UtcNow)
+                {
+                    RejectIdentity(context);
+                    return;
+                }
+            }
+        }
+
+        private static void RejectIdentity(CookieValidateIdentityContext context)
+        {
+            context.RejectIdentity();
+            context.OwinContext.Authentication.SignOut(context.Options.AuthenticationType);
         }
     }
 }

--- a/src/EA.Iws.Web/EA.Iws.Web.csproj
+++ b/src/EA.Iws.Web/EA.Iws.Web.csproj
@@ -65,20 +65,20 @@
       <HintPath>..\packages\Autofac.WebApi2.3.4.0\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Web.Mvc.1.0.16048-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
+    <Reference Include="EA.Prsd.Core, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Web.Mvc.1.0.16077-develop1\lib\net452\EA.Prsd.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core.Autofac, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Autofac.1.0.16048-develop1\lib\net452\EA.Prsd.Core.Autofac.dll</HintPath>
+    <Reference Include="EA.Prsd.Core.Autofac, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Autofac.1.0.16077-develop1\lib\net452\EA.Prsd.Core.Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core.Web, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Web.Mvc.1.0.16048-develop1\lib\net452\EA.Prsd.Core.Web.dll</HintPath>
+    <Reference Include="EA.Prsd.Core.Web, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Web.Mvc.1.0.16077-develop1\lib\net452\EA.Prsd.Core.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EA.Prsd.Core.Web.Mvc, Version=1.0.16048.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EA.Prsd.Core.Web.Mvc.1.0.16048-develop1\lib\net452\EA.Prsd.Core.Web.Mvc.dll</HintPath>
+    <Reference Include="EA.Prsd.Core.Web.Mvc, Version=1.0.16077.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EA.Prsd.Core.Web.Mvc.1.0.16077-develop1\lib\net452\EA.Prsd.Core.Web.Mvc.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Elmah, Version=1.2.14706.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/EA.Iws.Web/packages.config
+++ b/src/EA.Iws.Web/packages.config
@@ -6,10 +6,10 @@
   <package id="Autofac.Mvc5.Owin" version="3.1.0" targetFramework="net452" />
   <package id="Autofac.Owin" version="3.1.0" targetFramework="net452" />
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net452" />
-  <package id="EA.Prsd.Core" version="1.0.16048-develop1" targetFramework="net452" />
-  <package id="EA.Prsd.Core.Autofac" version="1.0.16048-develop1" targetFramework="net452" />
-  <package id="EA.Prsd.Core.Web" version="1.0.16048-develop1" targetFramework="net452" />
-  <package id="EA.Prsd.Core.Web.Mvc" version="1.0.16048-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core" version="1.0.16077-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core.Autofac" version="1.0.16077-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core.Web" version="1.0.16077-develop1" targetFramework="net452" />
+  <package id="EA.Prsd.Core.Web.Mvc" version="1.0.16077-develop1" targetFramework="net452" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net452" />
   <package id="Elmah.Mvc" version="2.1.2" targetFramework="net452" />
   <package id="font-awesome" version="4.3.0" targetFramework="net452" />


### PR DESCRIPTION
This should be more robust than the current implementation as it no longer uses the refresh token to get a new access token if it has expired. 12 hour access token should be more than enough for most users to get through the day. 