### PR TITLE
Update logic for elapsed days since assessment started

### DIFF
--- a/src/EA.Iws.RequestHandlers/Mappings/Reports/DataExportNotificationMap.cs
+++ b/src/EA.Iws.RequestHandlers/Mappings/Reports/DataExportNotificationMap.cs
@@ -43,12 +43,14 @@
 
         private int? GetAssessmentStartedElapsedWorkingDays(DataExportNotification source, UKCompetentAuthority parameter)
         {
-            if (!source.PaymentReceived.HasValue || !source.AssessmentStarted.HasValue)
+            if (!source.PaymentReceived.HasValue || !source.AssessmentStarted.HasValue || !source.NotificationReceived.HasValue)
             {
                 return null;
             }
 
-            return workingDayCalculator.GetWorkingDays(source.PaymentReceived.Value, source.AssessmentStarted.Value,
+            return workingDayCalculator.GetWorkingDays(
+                source.PaymentReceived.Value > source.NotificationReceived.Value ? source.PaymentReceived.Value : source.NotificationReceived.Value, 
+                source.AssessmentStarted.Value,
                 false, parameter);
         }
 


### PR DESCRIPTION
Fix for SFW18999.

Use most recent date between notification received and payment received to calculate the difference between assessment started date