### PR TITLE
Import shipment - no prenote received

### DIFF
--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/CaptureMovement/_Prenotify.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/CaptureMovement/_Prenotify.cshtml
@@ -16,7 +16,7 @@
         <fieldset>
             <div>@Html.Gds().ValidationMessageFor(m => m.HasNoPrenotification)</div>
             <label class="block-label" for="@Html.NameFor(m => m.HasNoPrenotification)">
-                @Html.CheckBoxFor(m => m.HasNoPrenotification, new { data_track = "element", data_category = "Terms and conditions", data_action = "Accept" })
+                @Html.CheckBoxFor(m => m.HasNoPrenotification)
                 @Html.DisplayNameFor(m => m.HasNoPrenotification)
             </label>
         </fieldset>

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/ViewModels/Capture/CreateViewModel.cs
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/ViewModels/Capture/CreateViewModel.cs
@@ -1,24 +1,38 @@
 ﻿namespace EA.Iws.Web.Areas.AdminImportNotificationMovements.ViewModels.Capture
 {
+    using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using Infrastructure.Validation;
     using Web.ViewModels.Shared;
 
-    public class CreateViewModel
+    public class CreateViewModel : IValidatableObject
     {
         public int Number { get; set; }
 
-        [RequiredDateInput(ErrorMessageResourceName = "ActualShipmentDateRequired", ErrorMessageResourceType = typeof(CreateViewModelResources))]
+        [RequiredDateInput(ErrorMessageResourceName = "ActualShipmentDateRequired",
+            ErrorMessageResourceType = typeof(CreateViewModelResources))]
         [Display(Name = "ActualShipmentDate", ResourceType = typeof(CreateViewModelResources))]
         public OptionalDateInputViewModel ActualShipmentDate { get; set; }
 
         [Display(Name = "PrenotificationDate", ResourceType = typeof(CreateViewModelResources))]
         public OptionalDateInputViewModel PrenotificationDate { get; set; }
 
+        [Display(Name = "HasNoPrenotification", ResourceType = typeof(CreateViewModelResources))]
+        public bool HasNoPrenotification { get; set; }
+
         public CreateViewModel()
         {
             ActualShipmentDate = new OptionalDateInputViewModel(true);
             PrenotificationDate = new OptionalDateInputViewModel(true);
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (!HasNoPrenotification && !PrenotificationDate.IsCompleted)
+            {
+                yield return new ValidationResult(CreateViewModelResources.PrenotificationDateRequired,
+                    new[] { "PrenotificationDate" });
+            }
         }
     }
 }

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/ViewModels/Capture/CreateViewModelResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/ViewModels/Capture/CreateViewModelResources.Designer.cs
@@ -80,11 +80,29 @@ namespace EA.Iws.Web.Areas.AdminImportNotificationMovements.ViewModels.Capture {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No prenotification received.
+        /// </summary>
+        public static string HasNoPrenotification {
+            get {
+                return ResourceManager.GetString("HasNoPrenotification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Prenotification date.
         /// </summary>
         public static string PrenotificationDate {
             get {
                 return ResourceManager.GetString("PrenotificationDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please tick the box or enter prenotification received date.
+        /// </summary>
+        public static string PrenotificationDateRequired {
+            get {
+                return ResourceManager.GetString("PrenotificationDateRequired", resourceCulture);
             }
         }
     }

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/ViewModels/Capture/CreateViewModelResources.resx
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/ViewModels/Capture/CreateViewModelResources.resx
@@ -123,7 +123,13 @@
   <data name="ActualShipmentDateRequired" xml:space="preserve">
     <value>Please provide the actual shipment date</value>
   </data>
+  <data name="HasNoPrenotification" xml:space="preserve">
+    <value>No prenotification received</value>
+  </data>
   <data name="PrenotificationDate" xml:space="preserve">
     <value>Prenotification date</value>
+  </data>
+  <data name="PrenotificationDateRequired" xml:space="preserve">
+    <value>Please tick the box or enter prenotification received date</value>
   </data>
 </root>

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Views/Capture/Create.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Views/Capture/Create.cshtml
@@ -20,3 +20,32 @@
 @section menu {
     @Html.Action("ImportNavigation", "Menu", new { area = "Admin", section = ImportNavigationSection.Shipments })
 }
+
+@section scripts {
+    <script>
+        var prenotificationDateSelector = $("#PrenotificationDate_Day, #PrenotificationDate_Month, #PrenotificationDate_Year");
+
+        function togglePrenotificationDate(checked) {
+            if (checked) {
+                prenotificationDateSelector
+                    .val('')
+                    .attr('readonly', true)
+                    .css('background-color', '#DEDEDE')
+                    .css('color', 'gray');
+            } else {
+                prenotificationDateSelector
+                    .attr('readonly', false)
+                    .css('background-color', 'white')
+                    .css('color', 'black');
+            }
+        }
+
+        togglePrenotificationDate($('#HasNoPrenotification').is(':checked'));
+
+        $(function () {
+            $("#HasNoPrenotification").click(function () {
+                togglePrenotificationDate($('#HasNoPrenotification').is(':checked'));
+            });
+        });
+    </script>
+}

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Views/Capture/_Prenotify.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Views/Capture/_Prenotify.cshtml
@@ -12,6 +12,16 @@
         @Html.EditorFor(m => m.PrenotificationDate)
     </div>
 
+    <div class="form-group @Html.Gds().FormGroupClass(m => m.HasNoPrenotification)">
+        <fieldset>
+            <div>@Html.Gds().ValidationMessageFor(m => m.HasNoPrenotification)</div>
+            <label class="block-label" for="@Html.NameFor(m => m.HasNoPrenotification)">
+                @Html.CheckBoxFor(m => m.HasNoPrenotification)
+                @Html.DisplayNameFor(m => m.HasNoPrenotification)
+            </label>
+        </fieldset>
+    </div>
+
     <div class="form-group @Html.Gds().FormGroupClass(m => m.ActualShipmentDate) @Html.Gds().FormGroupClass(m => m.ActualShipmentDate.Day) @Html.Gds().FormGroupClass(m => m.ActualShipmentDate.Month) @Html.Gds().FormGroupClass(m => m.ActualShipmentDate.Year)">
         @Html.LabelFor(m => m.ActualShipmentDate, new { @class = "heading-small" })
         @Html.Gds().ValidationMessageFor(m => m.ActualShipmentDate)


### PR DESCRIPTION
I've not added any domain logic to save whether the user checked the checkbox, which we did for export shipments. This is because for exports the shipment could be entered by the external user, where the prenotification date is required, or by the internal user where it is optional. Import shipments can only be entered by internal users, so the prenotification date will either be entered or not. From this commit on, if the user checked the box then the prenotification date will be null in the database.