### PR TITLE
Update script to set CreatedBy when there is no AuditLog record

### DIFF
--- a/src/EA.Iws.Database/scripts/Update/0002-CI/Sprint5/20161209-111900-add-created-by-to-movement.sql
+++ b/src/EA.Iws.Database/scripts/Update/0002-CI/Sprint5/20161209-111900-add-created-by-to-movement.sql
@@ -13,6 +13,15 @@ WHERE A.EventType = 0; -- Added
 
 GO
 
+-- If there was no AuditLog record then set CreatedBy to Notification UserId
+UPDATE [Notification].[Movement]
+SET [CreatedBy] = N.[UserId]
+FROM [Notification].[Movement] M
+INNER JOIN [Notification].[Notification] N ON M.NotificationId = N.Id
+WHERE M.CreatedBy IS NULL;
+
+GO
+
 ALTER TABLE [Notification].[Movement]
 ALTER COLUMN [CreatedBy] NVARCHAR(128) NOT NULL;
 
@@ -33,6 +42,16 @@ WHERE A.EventType = 0; -- Added
 
 GO
 
+-- If there was no AuditLog record then set CreatedBy to Notification UserId
+UPDATE [Notification].[MovementReceipt]
+SET [CreatedBy] = N.[UserId]
+FROM [Notification].[MovementReceipt] MR
+INNER JOIN [Notification].[Movement] M ON MR.MovementId = M.Id
+INNER JOIN [Notification].[Notification] N ON M.NotificationId = N.Id
+WHERE MR.CreatedBy IS NULL;
+
+GO
+
 ALTER TABLE [Notification].[MovementReceipt]
 ALTER COLUMN [CreatedBy] NVARCHAR(128) NOT NULL;
 
@@ -50,6 +69,16 @@ SET [CreatedBy] = A.[UserId]
 FROM [Notification].[MovementOperationReceipt] M
 INNER JOIN [Auditing].[AuditLog] A ON M.Id = A.RecordId
 WHERE A.EventType = 0; -- Added
+
+GO
+
+-- If there was no AuditLog record then set CreatedBy to Notification UserId
+UPDATE [Notification].[MovementOperationReceipt]
+SET [CreatedBy] = N.[UserId]
+FROM [Notification].[MovementOperationReceipt] MOR
+INNER JOIN [Notification].[Movement] M ON MOR.MovementId = M.Id
+INNER JOIN [Notification].[Notification] N ON M.NotificationId = N.Id
+WHERE MOR.CreatedBy IS NULL;
 
 GO
 


### PR DESCRIPTION
This will take the user id from the Notification table. While not ideal this is only an issue on system test and UAT environments. All movement records on the live database have the appropriate AuditLog records.